### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+ifeq ($(OS),Windows_NT)
+	LN = mklink /D client\assets\gltf ..\..\..\robocraft-1\gltf
+else
+	LN = ln -s ../../../robocraft-1/gltf client/assets/gltf
+endif
+
+
+bobocraft: client/assets/gltf
+	BEVY_ASSET_PATH="$(CURDIR)/client/assets" cargo build
+
+client/assets/gltf:
+	$(LN)
+
+clean:
+	cargo clean
+
+.PHONY: bobocraft clean


### PR DESCRIPTION
Creates a symlink and runs `cargo build`,
I'm unsure of wether or not it works on Binbows, 
though Binbows people usually prefer an .exe anyway.